### PR TITLE
Added a tail recursive List.concat implementation

### DIFF
--- a/lib/globalLocal.ml
+++ b/lib/globalLocal.ml
@@ -146,7 +146,7 @@ module Global = struct
         head @ tail
 
       | OutOfOrder (g1, g2) ->
-        let g1_roles = get_lts g1 [] |> List.map (fun (_, lbl, _) -> [lbl.sender ; lbl.receiver]) |> List.concat |> Utils.uniq in
+        let g1_roles = get_lts g1 [] |> List.map (fun (_, lbl, _) -> [lbl.sender ; lbl.receiver]) |> Utils.List.concat |> Utils.uniq in
 
         let l1 = get_lts_head g1 |> List.map (fun (l, g') -> (l, OutOfOrder(g', g2))) in
         let l2 = get_lts_head g2
@@ -156,7 +156,7 @@ module Global = struct
         l1 @ l2
 
       | Choice gs ->
-        List.map get_lts_head gs |> List.concat
+        List.map get_lts_head gs |> Utils.List.concat
 
       | Fin g' ->
         List.map (fun (l, g'') -> l, Seq [g'' ; Fin g']) (get_lts_head g')
@@ -217,7 +217,7 @@ module Global = struct
       if List.mem g visited then []
       else
         let lts_hd = get_lts_head g in
-        List.map (fun (l, g') -> (g, l, g')::get_lts g' (g::visited)) lts_hd |> List.concat
+        List.map (fun (l, g') -> (g, l, g')::get_lts g' (g::visited)) lts_hd |> Utils.List.concat
     in
 
 

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -28,7 +28,7 @@ struct
       match xss with
       | [] -> List.rev acc
       | xs::xss -> tail xss (xs @ acc)
-      in tail xss []
+    in tail xss []
 end
 
 let  split_3 l =

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -27,7 +27,7 @@ struct
       let (@) = List.rev_append in 
       match xss with
       | [] -> List.rev acc
-      | xs::xss -> tail xss ( xs @ acc)
+      | xs::xss -> tail xss (xs @ acc)
       in tail xss []
 end
 

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -21,6 +21,13 @@ struct
     f (rev l1) l2
 
   let (@) = append
+  
+  let concat (xss : 'a list list) : 'a list =
+    let rec tail xss acc =
+      match xss with
+      | [] -> acc
+      | xs::xss -> tail xss (acc @ xs)
+    in tail xss []
 end
 
 let  split_3 l =

--- a/lib/utils.ml
+++ b/lib/utils.ml
@@ -24,10 +24,11 @@ struct
   
   let concat (xss : 'a list list) : 'a list =
     let rec tail xss acc =
+      let (@) = List.rev_append in 
       match xss with
-      | [] -> acc
-      | xs::xss -> tail xss (acc @ xs)
-    in tail xss []
+      | [] -> List.rev acc
+      | xs::xss -> tail xss ( xs @ acc)
+      in tail xss []
 end
 
 let  split_3 l =

--- a/lib/utils.mli
+++ b/lib/utils.mli
@@ -1,6 +1,7 @@
 module List : sig
   val fold_left : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
   val (@) : 'a list -> 'a list -> 'a list
+  val concat : 'a list list -> 'a list
 end
 
 


### PR DESCRIPTION
to avoid stack overflow, replaced List.concat with version that uses a tail recursive tail recursive append in Utils.List